### PR TITLE
feat: added radio button and checkbox components

### DIFF
--- a/src/presentation/components/common/checkbox-input/CustomCheckBoxInput.tsx
+++ b/src/presentation/components/common/checkbox-input/CustomCheckBoxInput.tsx
@@ -1,0 +1,16 @@
+import { Checkbox, styled } from "@mui/material";
+
+const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
+  color: "#D5D0DB",
+  "&.Mui-checked": {
+    color: "#8C32D9",
+  },
+  "& .MuiSvgIcon-root": {
+    fontSize: 24,
+  },
+  "&.Mui-disabled": {
+    color: "#5B5266",
+  },
+}));
+
+export default CustomCheckbox;

--- a/src/presentation/components/common/radio-input/CustomRadioInput.tsx
+++ b/src/presentation/components/common/radio-input/CustomRadioInput.tsx
@@ -1,0 +1,16 @@
+import { Radio, styled } from "@mui/material";
+
+const CustomRadio = styled(Radio)(({ theme }) => ({
+  color: "#F7F5FA",
+  "&.Mui-checked": {
+    color: "#8C32D9",
+  },
+  "&.Mui-disabled": {
+    color: "#5B5266",
+  },
+  "& .MuiSvgIcon-root": {
+    fontSize: 24,
+  },
+}));
+
+export default CustomRadio;

--- a/src/presentation/components/common/radio-input/IRadioInput.ts
+++ b/src/presentation/components/common/radio-input/IRadioInput.ts
@@ -1,0 +1,9 @@
+export interface RadioInputProps {
+  option: { value: string; label: string; disabled?: boolean };
+  selectedValue: any;
+}
+
+export interface RadioInputGroupProps {
+  options: { value: string, label: string, disabled?: boolean }[];
+  label?: string;
+}

--- a/src/presentation/components/common/radio-input/RadioInputGroup.tsx
+++ b/src/presentation/components/common/radio-input/RadioInputGroup.tsx
@@ -1,0 +1,40 @@
+import RadioInput from "src/presentation/feature/radio-input/RadioInput";
+import { FormControl, FormLabel, RadioGroup } from "@mui/material";
+import { useState } from "react";
+import { RadioInputGroupProps } from "./IRadioInput";
+
+const RadioInputGroup: React.FC<RadioInputGroupProps> = ({
+  options,
+  label,
+}) => {
+  const [selectedValue, setSelectedValue] = useState<string>("");
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedValue(event.target.value);
+  };
+  return (
+    <FormControl>
+      {label && (
+        <FormLabel id="Sample1" sx={{ color: "#F7F5FA" }}>
+          {label}
+        </FormLabel>
+      )}
+      <RadioGroup
+        aria-labelledby="Sample1"
+        name="First Sample"
+        value={selectedValue}
+        onChange={handleChange}
+      >
+        {options.map((option) => (
+          <RadioInput
+            option={option}
+            selectedValue={selectedValue}
+            key={option.value}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+};
+
+export default RadioInputGroup;

--- a/src/presentation/feature/base-checkbox/BaseCheckbox.styles.ts
+++ b/src/presentation/feature/base-checkbox/BaseCheckbox.styles.ts
@@ -1,0 +1,21 @@
+import { Checkbox, styled } from "@mui/material";
+import { BaseCheckboxProps } from "./IBaseCheckbox";
+
+export const StyledCheckbox = styled(Checkbox, {
+    shouldForwardProp: (prop) =>
+        prop !== "checkedColor" && prop !== "uncheckedColor",
+})<BaseCheckboxProps>(
+    ({ checkedColor = "#8C32D9", uncheckedColor = "#F7F5FA", disabled }) => ({
+        color: uncheckedColor,
+        padding: 0,
+        "&.Mui-checked": {
+            color: checkedColor,
+        },
+        transition: "color 0.3s ease",
+        "&.Mui-disabled": {
+            color: "#5B5266",
+            borderColor: "red",
+            pointerEvents: "none",
+        },
+    })
+);

--- a/src/presentation/feature/base-checkbox/BaseCheckbox.tsx
+++ b/src/presentation/feature/base-checkbox/BaseCheckbox.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { BaseCheckboxProps } from "./IBaseCheckbox";
+import { StyledCheckbox } from "./BaseCheckbox.styles";
+
+const BaseCheckbox: React.FC<BaseCheckboxProps> = ({
+  checkedColor,
+  uncheckedColor,
+  text,
+  disabled,
+  ...props
+}) => {
+  const [checked, setChecked] = useState(false);
+  return (
+    <span
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        color: disabled ? "#5B5266" : "#F7F5FA",
+      }}
+    >
+      <StyledCheckbox
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+        checkedColor={checkedColor}
+        uncheckedColor={uncheckedColor}
+        disabled={disabled}
+        icon={<UncheckIcon disabled={disabled} />}
+        checkedIcon={<CheckIcon disabled={disabled} />}
+        {...props}
+      />
+      <span>{text}</span>
+    </span>
+  );
+};
+
+export default BaseCheckbox;
+
+// TODO:: These icons should be moved to the icons folder
+
+const UncheckIcon: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="0.5"
+        y="0.5"
+        width="23"
+        height="23"
+        rx="4.5"
+        stroke={disabled ? "#5B5266" : "#D5D0DB"}
+      />
+    </svg>
+  );
+};
+
+const CheckIcon: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        width="24"
+        height="24"
+        rx="5"
+        fill={disabled ? "#5B5266" : "#8C32D9"}
+      />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M19 7L9.375 16.625L5 12.25"
+        fill={disabled ? "#5B5266" : "#8C32D9"}
+      />
+      <path
+        d="M19 7L9.375 16.625L5 12.25"
+        stroke="#F7F5FA"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};

--- a/src/presentation/feature/base-checkbox/IBaseCheckbox.ts
+++ b/src/presentation/feature/base-checkbox/IBaseCheckbox.ts
@@ -1,0 +1,7 @@
+import { CheckboxProps } from "@mui/material";
+
+export interface BaseCheckboxProps extends CheckboxProps {
+    checkedColor?: string;
+    uncheckedColor?: string;
+    text?: string;
+}

--- a/src/presentation/feature/checkbox-input-group/CheckBoxInput.tsx
+++ b/src/presentation/feature/checkbox-input-group/CheckBoxInput.tsx
@@ -1,0 +1,40 @@
+import CustomCheckBox from "src/presentation/components/common/checkbox-input/CustomCheckBoxInput";
+import { FormControl, FormGroup, FormLabel } from "@mui/material";
+import { CheckBoxInputProps } from "./ICheckBoxInput";
+import { useState } from "react";
+import { FormControlLabelStyled } from "./CheckboxInput.styles";
+
+const CheckBoxInput: React.FC<CheckBoxInputProps> = ({ options, label }) => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+  const handleChange = (value: string) => {
+    setSelectedValues((prevValue) =>
+      prevValue.includes(value)
+        ? prevValue.filter((val) => val !== value)
+        : [...prevValue, value]
+    );
+  };
+  return (
+    <FormControl component="fieldset">
+      {label && <FormLabel component="legend">{label}</FormLabel>}
+      <FormGroup>
+        {options.map((option) => (
+          <FormControlLabelStyled
+            key={option.value}
+            control={
+              <CustomCheckBox
+                checked={selectedValues.includes(option.value)}
+                onChange={() => handleChange(option.value)}
+                disabled={option.disabled}
+              />
+            }
+            label={option.label}
+            selected={selectedValues.includes(option.value)}
+          />
+        ))}
+      </FormGroup>
+    </FormControl>
+  );
+};
+
+export default CheckBoxInput;

--- a/src/presentation/feature/checkbox-input-group/CheckboxInput.styles.ts
+++ b/src/presentation/feature/checkbox-input-group/CheckboxInput.styles.ts
@@ -1,0 +1,16 @@
+import { FormControlLabel, styled } from "@mui/material";
+
+export const FormControlLabelStyled = styled(FormControlLabel, {
+    shouldForwardProp: (prop) => prop !== 'selected',
+})<{ selected: boolean }>(({ theme, selected }) => ({
+    "& .MuiFormControlLabel-label": {
+        fontSize: "0.875rem",
+        color: selected ? "#F7F5FA" : "#B7B0BF",
+        fontWeight: "600"
+    },
+    "&.Mui-disabled": {
+        '& .MuiFormControlLabel-label': {
+            color: "#5B5266"
+        }
+    }
+}))

--- a/src/presentation/feature/checkbox-input-group/ICheckBoxInput.ts
+++ b/src/presentation/feature/checkbox-input-group/ICheckBoxInput.ts
@@ -1,0 +1,4 @@
+export interface CheckBoxInputProps {
+    options: { value: string, label: string, disabled?: boolean }[],
+    label?: string,
+}

--- a/src/presentation/feature/radio-input/RadioInput.tsx
+++ b/src/presentation/feature/radio-input/RadioInput.tsx
@@ -1,0 +1,29 @@
+import { FormControlLabel } from "@mui/material";
+import CustomRadio from "src/presentation/components/common/radio-input/CustomRadioInput";
+import { RadioInputProps } from "src/presentation/components/common/radio-input/IRadioInput";
+
+const RadioInput: React.FC<RadioInputProps> = ({ option, selectedValue }) => {
+  return (
+    <FormControlLabel
+      key={option.value}
+      value={option.value}
+      control={<CustomRadio />}
+      label={option.label}
+      disabled={option.disabled}
+      sx={{
+        "& .MuiFormControlLabel-label": {
+          fontSize: "0.875rem",
+          color: selectedValue === option.value ? "#F7F5FA" : "#B7B0BF",
+          fontWeight: 600,
+        },
+        "&.Mui-disabled": {
+          "& .MuiFormControlLabel-label": {
+            color: "#5B5266",
+          },
+        },
+      }}
+    />
+  );
+};
+
+export default RadioInput;


### PR DESCRIPTION
کامپوننت رادیو باتن و چک باکس اضافه شد 
برای تست کد زیر استفاده بشه:
// دیتای تست
const options = [
    { value: "option1", label: "متن رادیو باتن", disabled: false },
    { value: "option2", label: "متن رادیو باتن", disabled: true },
    { value: "option3", label: "متن رادیو باتن", disabled: false },
  ]; 
// کامپوننتی که باید کال بشه:
<>
      <div
        style={{
          backgroundColor: "#222",
        }}
      >
        <RadioInputGroup options={options} />
      </div>
      <div
        style={{
          backgroundColor: "#222",
        }}
      >
        <CheckBoxInput options={options} />
      </div>
    </>